### PR TITLE
Redirecting route from installer to knowledgebase panel (disable web-installer)

### DIFF
--- a/public/css/wizard.css
+++ b/public/css/wizard.css
@@ -264,3 +264,14 @@ ul.button-groups > li:last-child {
     font-size: 16px;
     vertical-align: text-bottom;
 }
+
+.uv-next-step {
+    margin-top: 35px;
+}
+
+.uv-next-step h1 {
+    font-size: 2em;
+    font-weight: bold;
+    line-height: 1.4em;
+    color: #8b6bfa;
+}

--- a/public/scripts/wizard.js
+++ b/public/scripts/wizard.js
@@ -610,6 +610,12 @@
                 'click #wizardCTA-CancelInstallation': function() {
                     this.router.navigate('welcome', { trigger: true });
                 },
+                'click #wizard-RemoveSection': function () {
+                    let result = confirm("Are you sure about removing web installer");
+                    if (result) {
+                        $.get('./wizard/xhr/remove/installer');
+                    }
+                }
             },
             timeline: [
                 {

--- a/setup/Controller/InstallationWizardXHR.php
+++ b/setup/Controller/InstallationWizardXHR.php
@@ -402,4 +402,44 @@ class InstallationWizardXHR extends Controller
 
         return new Response(json_encode($collectionURL), 200, self::DEFAULT_JSON_HEADERS);
     }
+
+    public function removeInstallerConfigurationXHR()
+    {
+        $fileName = dirname(__File__, 3) . '/config/routes/uvdesk_support_center.yaml';
+        $file = file($fileName);
+
+        $updatedFileContent = $file;
+        if ($file) {
+            $fileEndingIndex = sizeof($file);
+
+            foreach ($updatedFileContent as $index => $fileContent) {
+                $isRouteExist = strpos($updatedFileContent[$index], 'uvdesk_support_center_bundle_use_locale:');
+
+                if ($isRouteExist !== false) {
+                    $isRouteExist = true;
+                    break;
+                }
+            }
+
+            if (!$isRouteExist) {
+                $contentToAdd = [
+                    PHP_EOL,
+                    'uvdesk_support_center_bundle_use_locale:' . PHP_EOL,
+                    '    path:     /' . PHP_EOL,
+                    '    controller: Symfony\Bundle\FrameworkBundle\Controller\RedirectController::urlRedirectAction' . PHP_EOL,
+                    '    defaults:' . PHP_EOL,
+                    '        path: /en/' . PHP_EOL,
+                    '        permanent: true' . PHP_EOL,
+                ];
+    
+                foreach ($contentToAdd as $index => $content) {
+                    $updatedFileContent[$fileEndingIndex + $index] = $content;
+                }
+                $isFileUpdated = file_put_contents($fileName, $updatedFileContent);
+            }
+
+        }
+
+        return new Response(json_encode([]), 200, self::DEFAULT_JSON_HEADERS);
+    }
 }

--- a/templates/installation-wizard/index.html.twig
+++ b/templates/installation-wizard/index.html.twig
@@ -225,6 +225,18 @@
                     <li style="display: inline-block;"><a href="<%- prefixCollecton.member %>" target="_blank" id="member_panel_url">Admin Panel</a></li>
                     <li style="display: inline-block;">| <a href="<%- prefixCollecton.knowledgebase %>" target="_blank" id="customer_panel_url">Knowledgebase</a></li>
                 </ul>
+                <div class="uv-next-step">
+                    <h1>What's Next?</h1>
+                    <ul class="button-groups">
+                        <li>
+                            <button id="wizard-RemoveSection" class="wizard-button solid button-theme-uvdesk" style="text-transform:unset;margin-top:27px;">
+                                <a href="<%- prefixCollecton.member %>" style="text-decoration:none;color:white;">
+                                    Disable installer and redirect to member login
+                                </a>
+                            </button>
+                        </li>
+                    </ul>
+                </div>
             </div>
         </script>
 


### PR DESCRIPTION
From now there will a option to redirect all requests from the route of installer to knowledgebase panel