### PR TITLE
Update ConfigureHelpdesk.php

### DIFF
--- a/src/Console/Wizard/ConfigureHelpdesk.php
+++ b/src/Console/Wizard/ConfigureHelpdesk.php
@@ -235,7 +235,7 @@ class ConfigureHelpdesk extends Command
         // Check 3: Check if super admin account exists
         $output->writeln("  [-] Checking if an active super admin account exists");
 
-        $database = new \PDO("mysql:host=$db_host;dbname=$db_name", $db_user, $db_password);
+        $database = new \PDO("mysql:host=$db_host:$db_port;dbname=$db_name", $db_user, $db_password);
 
         $supportRoleQuery = $database->query("SELECT * FROM uv_support_role WHERE code = 'ROLE_SUPER_ADMIN'");
         $supportRole = $supportRoleQuery->fetch(\PDO::FETCH_ASSOC);


### PR DESCRIPTION
In ConfigureHelpdesk.php line 238:

  [PDOException (2002)]
  SQLSTATE[HY000] [2002] Connection refused

Resolve above error

<!--
Thank you for contributing to UVDesk! Please fill out this description template to help us to process your pull request.
-->

### 1. Why is this change necessary?
It is giving mysql connection refused error if mysql is not running on port 3306

### 2. What does this change do, exactly?
Resolve MySQL connection error for port other then 3306

### 3. Please link to the relevant issues (if any).
