### PR TITLE
Pin all symfony packages versions to 4.3.*

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -86,6 +86,10 @@
     "extra": {
         "branch-alias": {
             "dev-master": "1.0.x-dev"
+        },
+        "symfony": {
+            "allow-contrib": false,
+            "require": "4.3.*"
         }
     },
     "minimum-stability": "dev"


### PR DESCRIPTION
Tune composer update strategy using `extra.symfony.require = 4.3.*` parameter.
It tells composer to keep symfony package in the 4.3 version globaly.

### 1. Why is this change necessary?
It's not necessary but it allows to do a clean `composer update` ans stay with a stable SF 4.3 API.

### 2. What does this change do, exactly?
Makes fix updates a little easier ?

### 3. Please link to the relevant issues (if any).
