### PR TITLE
Install composer v1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -59,7 +59,7 @@ RUN \
         exit 1; \
 	fi; \
     # Install composer
-    php /usr/local/bin/composer.php --quiet --filename=/usr/local/bin/composer \
+    php /usr/local/bin/composer.php --1 --quiet --filename=/usr/local/bin/composer \
     && chmod +x /usr/local/bin/composer; \
     # Assign user uvdesk the ownership of source directory
     chown -R uvdesk:uvdesk /var/www; \


### PR DESCRIPTION
<!--
Thank you for contributing to UVDesk! Please fill out this description template to help us to process your pull request.
-->

### 1. Why is this change necessary?

The current `Dockerfile` will install composer v2 which is not supported.


### 2. What does this change do, exactly?

This (small) change is using the standard `composer` install argument for choosing which major version to install.

### 3. Please link to the relevant issues (if any).
