### PR TITLE
Fix #392: Docker setup results in 500 Internal Server Error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -73,6 +73,13 @@ RUN \
         /var/www/html \
         /var/www/uvdesk/.docker;
 
+WORKDIR /var/www/uvdesk
+RUN composer update
+RUN composer install && \
+  chmod 777 /var/www/uvdesk/config/packages/uvdesk.yaml && \
+  chmod 777 /var/www/uvdesk/config/packages/swiftmailer.yaml && \
+  chmod 777 /var/www/uvdesk/config/packages/uvdesk_mailbox.yaml
+
 # Change working directory to uvdesk source
 WORKDIR /var/www
 


### PR DESCRIPTION
<!--
Thank you for contributing to UVDesk! Please fill out this description template to help us to process your pull request.
-->

### 1. Why is this change necessary?
After following instructions [here](https://github.com/uvdesk/community-skeleton/wiki/dockerize-helpdesk-project) user gets non-working Docker conatiner (500 Internal Server Error). Details explained here - https://github.com/uvdesk/community-skeleton/issues/392

### 2. What does this change do, exactly?
Added changes according to solution provided here - https://github.com/uvdesk/community-skeleton/issues/392#issuecomment-832982443

### 3. Please link to the relevant issues (if any).
https://github.com/uvdesk/community-skeleton/issues/392
https://github.com/uvdesk/community-skeleton/issues/229