### PR TITLE
Adding php-curl dependency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,7 @@ RUN apt-get update && apt-get -y upgrade \
         php-xml \
         php7.2-imap \
         php7.2-mysql \
+	php7.2-curl \
         php-mailparse \
         ca-certificates; \
     if ! command -v gpg; then \


### PR DESCRIPTION
<!--
Thank you for contributing to UVDesk! Please fill out this description template to help us to process your pull request.
-->

### 1. Why is this change necessary?

I just tried to install composer dependencies from within the container and got this message:

`Composer is operating significantly slower than normal because you do not have the PHP curl extension enabled.` while the console wasn't showing any output so I figured I'd install it before trying again.

It probably makes sense to add it to the Dockerfile

### 2. What does this change do, exactly?

It adds php7.2-curl to the docker image

### 3. Please link to the relevant issues (if any).
