### PR TITLE
redirect admin login instead of  dashboard

### DIFF
--- a/src/EventListener/ExceptionSubscriber.php
+++ b/src/EventListener/ExceptionSubscriber.php
@@ -48,7 +48,7 @@ class ExceptionSubscriber implements EventSubscriberInterface
 			// 		a) If user session is set, display forbidden page
 			// 		b) If user session is not set, redirect to login page
 
-			if (!empty($this->container->get('security.token_storage')->getToken()->getUser())) {
+			if (!empty($this->container->get('security.token_storage')->getToken()->getUser()) && $this->container->get('security.token_storage')->getToken()->getUser() != "anon.") {
 				$template = $this->twig->render('errors/error.html.twig', [
 					'code' => 403,
 					'message' => 'Access Forbidden',

--- a/src/EventListener/ExceptionSubscriber.php
+++ b/src/EventListener/ExceptionSubscriber.php
@@ -58,7 +58,7 @@ class ExceptionSubscriber implements EventSubscriberInterface
 				$event->setResponse(new Response($template, 403));
 			}
 		} else {
-			if ($exception instanceof NotFoundHttpException) {
+			if ($exception instanceof NotFoundHttpException || $exception->getCode() == 404) {
 				$template = $this->twig->render('errors/error.html.twig', [
 					'code' => 404,
 					'message' => 'Page not Found',

--- a/templates/errors/error.html.twig
+++ b/templates/errors/error.html.twig
@@ -59,7 +59,7 @@
 	<div class="uv-box-server-error">
 		<div class="uv-box-server-error-lt">
 			{% if websiteDetails %}
-				<a class="uv-logo" href="{{ path('helpdesk_member_dashboard') }}">
+				<a class="uv-logo" href="{{ path('helpdesk_member_handle_login') }}">
 					{% if websiteDetails.logo %}
 						<img src="{{ app.request.scheme ~'://' ~ app.request.httpHost ~ asset('') }}{{ websiteDetails.logo }}" title="{{ websiteDetails.name }}">
 					{% else %}


### PR DESCRIPTION
<!--
Thank you for contributing to UVDesk! Please fill out this description template to help us to process your pull request.
-->

### 1. Why is this change necessary?
If a customer is on the error page & click on the logo then it will redirect admin login instead of the dashboard.

### 2. What does this change do, exactly?
Update.

### 3. Please link to the relevant issues (if any).
https://github.com/uvdesk/core-framework/issues/487