### PR TITLE
added 'getThrowable' function, as 'getException' function depreciated.

### DIFF
--- a/src/EventListener/ExceptionSubscriber.php
+++ b/src/EventListener/ExceptionSubscriber.php
@@ -41,7 +41,11 @@ class ExceptionSubscriber implements EventSubscriberInterface
 		}
 
 		// @TODO: We need to take into account the response type as well (html, xml, json)
-		$exception = $event->getException();
+		if (method_exists($event, 'getThrowable')) {
+            $exception = $event->getThrowable();
+        } else {
+            $exception = $event->getException();
+        }
 
 		if ($exception->getCode() == 403) {
 			// On forbidden exception, we need to either:


### PR DESCRIPTION
<!--
Thank you for contributing to UVDesk! Please fill out this description template to help us to process your pull request.
-->

### 1. Why is this change necessary?
As getException' function depreciated in Symfony 5. It is not allowing to getCode() function so that the default 500 error page comes up.

### 2. What does this change do, exactly?
Have added 'getThrowable' function. Now, it will prove the exception code & all the error pages are working fine.

### 3. Please link to the relevant issues (if any).
https://github.com/uvdesk/core-framework/issues/556