### PR TITLE
Update error.html.twig

### DIFF
--- a/templates/errors/error.html.twig
+++ b/templates/errors/error.html.twig
@@ -59,7 +59,7 @@
 	<div class="uv-box-server-error">
 		<div class="uv-box-server-error-lt">
 			{% if websiteDetails %}
-				<a class="uv-logo" href="{{ path('helpdesk_member_handle_login') }}">
+				<a class="uv-logo" href="{{ path('helpdesk_customer_login') }}">
 					{% if websiteDetails.logo %}
 						<img src="{{ app.request.scheme ~'://' ~ app.request.httpHost ~ asset('') }}{{ websiteDetails.logo }}" title="{{ websiteDetails.name }}">
 					{% else %}


### PR DESCRIPTION
The logo of an error page should not redirect the user to the operator admin area but to the user login area.

Actually UVdesk logo, on a error page, redirect the user to the operator login so user will get always login error. 
This should be fixed.

Also maybe I won't expose my operator login link as is not present by default, in the interface, in any page.
What sense has insert the link in the error logo page that should work for the user?

the results will be: users unable to login.