### PR TITLE
Updated redirection for customer and agent when click on logo on erro…

### DIFF
--- a/CHANGELOG-1.1.md
+++ b/CHANGELOG-1.1.md
@@ -3,6 +3,10 @@ CHANGELOG for 1.1.x
 
 This changelog references any relevant changes introduced in 1.1 minor versions.
 
+* 1.1.x 
+    * PR #554: Updated redirection for customer and agent when click on logo on error page (papnoisanjeev)
+    * PR #556: Updated wrong redirection on links with error page (vipin-shrivastava)
+
 * 1.1.0 (2022-03-25)
     * Feature: Improved compatibility with PHP 8 and Symfony 5 components
     * Bug #546: Use *getThrowable()* instead of deprecated *getException()* function in *ExceptionSubscriber.php* (vipin-shrivastava)

--- a/templates/errors/error.html.twig
+++ b/templates/errors/error.html.twig
@@ -59,7 +59,7 @@
 	<div class="uv-box-server-error">
 		<div class="uv-box-server-error-lt">
 			{% if websiteDetails %}
-				<a class="uv-logo" href="{{ path('helpdesk_member_handle_login') }}">
+				<a class="uv-logo" href="{{  'public/en/member' in currentPath  ? (websiteDetails ? path('helpdesk_member_dashboard') : app.request.scheme ~'://' ~ app.request.httpHost ) : path('helpdesk_customer_login')}}">
 					{% if websiteDetails.logo %}
 						<img src="{{ app.request.scheme ~'://' ~ app.request.httpHost ~ asset('') }}{{ websiteDetails.logo }}" title="{{ websiteDetails.name }}">
 					{% else %}


### PR DESCRIPTION
…r page

<!--
Thank you for contributing to UVDesk! Please fill out this description template to help us to process your pull request.
-->

### 1. Why is this change necessary?
For a correct redirection for customer and agent  in case of any error.

### 2. What does this change do, exactly?
Redirect the customer and agent to their respective area when click on uvdesk logo on error page.

### 3. Please link to the relevant issues (if any).
#551 