### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,9 @@
 FROM ubuntu:latest
 LABEL maintainer="akshay.kumar758@webkul.com"
 
-ENV GOSU_VERSION 1.11
+ENV GOSU_VERSION=1.11
 
+RUN apt-get update && apt-get install -y adduser
 RUN adduser uvdesk -q --disabled-password --gecos ""
 
 # Install base supplimentary packages


### PR DESCRIPTION
standardized the env format and resolved the non-existent command error in ubuntu

<!--
Thank you for contributing to UVDesk! Please fill out this description template to help us to process your pull request.
-->

### 1. Why is this change necessary?
standardized the env format and resolved the non-existent command error in ubuntu


### 2. What does this change do, exactly?
To run docker build correctly


### 3. Please link to the relevant issues (if any).
