### PR TITLE
Update uvdesk-entrypoint.sh

### DIFF
--- a/.docker/bash/uvdesk-entrypoint.sh
+++ b/.docker/bash/uvdesk-entrypoint.sh
@@ -12,12 +12,6 @@ declare -r COLOR_LIGHT_YELLOW='\033[0;33m'
 declare -r COLOR_BLUE='\033[0;34m'
 declare -r COLOR_LIGHT_BLUE='\033[1;34m'
 
-service mysql stop;
-usermod -d /var/lib/mysql/ mysql;
-
-# Restart apache & mysql server
-service apache2 restart && service mysql restart;
-
 # @TODO: Debug. Returning access denied warning during container start up.
 # if [[ ! -z "$MYSQL_USER" && ! -z "$MYSQL_PASSWORD" && ! -z "$MYSQL_DATABASE" ]]; then
 #     if [ "$(mysqladmin ping)" == "mysqld is alive" ]; then


### PR DESCRIPTION
the image generated in the dockerfile does not have mysql, they are separate services so I removed the mysql commands

<!--
Thank you for contributing to UVDesk! Please fill out this description template to help us to process your pull request.
-->

### 1. Why is this change necessary?
the image generated in the dockerfile does not have mysql, they are separate services so I removed the mysql commands


### 2. What does this change do, exactly?
delete commands used to mysql


### 3. Please link to the relevant issues (if any).
