### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ LABEL maintainer="akshay.kumar758@webkul.com"
 
 ENV GOSU_VERSION 1.11
 
-RUN adduser uvdesk -q --disabled-password --gecos ""
+RUN useradd -m -s /bin/bash uvdesk
 
 # Install base supplimentary packages
 RUN apt-get update && apt-get -y upgrade \


### PR DESCRIPTION
fix missing adduser command

<!--
Thank you for contributing to UVDesk! Please fill out this description template to help us to process your pull request.
-->

### 1. Why is this change necessary?
docker won't build the image

### 2. What does this change do, exactly?
adduser command is replaced by useradd

### 3. Please link to the relevant issues (if any).
