### PR TITLE
Add 'no-interaction' mode to configure wizard

### DIFF
--- a/config/bundles.php
+++ b/config/bundles.php
@@ -7,4 +7,5 @@ return [
     Webkul\UVDesk\MailboxBundle\UVDeskMailboxBundle::class => ['all' => true],
     Webkul\UVDesk\SupportCenterBundle\UVDeskSupportCenterBundle::class => ['all' => true],
     Webkul\UVDesk\ApiBundle\UVDeskApiBundle::class => ['all' => true],
+    Doctrine\Bundle\FixturesBundle\DoctrineFixturesBundle::class => ['all' => true],
 ];

--- a/src/Console/Wizard/ConfigureHelpdesk.php
+++ b/src/Console/Wizard/ConfigureHelpdesk.php
@@ -50,6 +50,10 @@ class ConfigureHelpdesk extends Command
             ->setName('uvdesk:configure-helpdesk')
             ->setDescription('Scans through your helpdesk setup to check for any mis-configurations.')
         ;
+        
+        $this
+            ->addOption('no-interaction', 'n', \Symfony\Component\Console\Input\InputOption::VALUE_NONE, 'Do not ask any interactive questions')
+        ;
     }
 
     protected function initialize(InputInterface $input, OutputInterface $output)
@@ -64,6 +68,8 @@ class ConfigureHelpdesk extends Command
         $config = $this->projectDirectory.'/config';
         $public = $this->projectDirectory.'/public';
         $migrations = $this->projectDirectory.'/migrations';
+
+        $noInteraction = $input->getOption('no-interaction');
 
         $files = [
             'env'        => $env,
@@ -102,51 +108,32 @@ class ConfigureHelpdesk extends Command
         if (false == $isServerAccessible || false == $isDatabaseAccessible) {
             $output->writeln("<fg=red;>  [x]</> Unable to establish a connection with database server</>");
 
-            // Interactively prompt user to re-configure their database
-            $interactiveQuestion = new Question("\n      <comment>Proceed with re-configuring your database credentials? [Y/N]</comment> ", 'Y');
+            
 
-            if ('Y' === strtoupper($this->questionHelper->ask($input, $output, $interactiveQuestion))) {
-                $continue = false;
-                $output->write([self::MCA, self::CLL, self::MCA, self::CLL]);
+            if (!$noInteraction) {
 
-                do {
+                // Interactively prompt user to re-configure their database
+                $interactiveQuestion = new Question("\n      <comment>Proceed with re-configuring your database credentials? [Y/N]</comment> ", 'Y');
+
+                if ('Y' === strtoupper($this->questionHelper->ask($input, $output, $interactiveQuestion))) {
                     $continue = false;
-                    $output->writeln("\n      <comment>Please enter the following details:</comment>\n");
-    
-                    $db_host = $this->askInteractiveQuestion("<info>Database Host</info>: ", '127.0.0.1', 6, false, false, "Please enter a host address");
-                    $db_port = $this->askInteractiveQuestion("<info>Database Port</info>: ", '3306', 6, false, false, "Please enter a host port number");
-                    $db_name = $this->askInteractiveQuestion("<info>Database Name</info>: ", null, 6, false, false, "Please enter name of the database you wish to connect with");
-                    $db_user = $this->askInteractiveQuestion("<info>Database User Name</info>: ", null, 6, false, false, "Please enter your user name to connect with the database");
-                    $db_password = $this->askInteractiveQuestion("<info>Database User Password</info>: ", null, 6, false, true, "Please enter your user password to connect with the database");
-    
-                    $output->write([self::MCA, self::CLL, self::MCA, self::CLL, self::MCA, self::CLL]);
+                    $output->write([self::MCA, self::CLL, self::MCA, self::CLL]);
 
-                    list($isServerAccessible, $isDatabaseAccessible) = $this->refreshDatabaseConnection($db_host, $db_port, $db_name, $db_user, $db_password);
+                    do {
+                        $continue = false;
+                        $output->writeln("\n      <comment>Please enter the following details:</comment>\n");
 
-                    if (false == $isServerAccessible) {
-                        $interactiveQuestion = new Question("\n      <comment>Unable to connect with your database server, please check the details provided.\n      Do you wish to try again? [Y/N]</comment> ", 'Y');
-
-                        if ('Y' === strtoupper($this->questionHelper->ask($input, $output, $interactiveQuestion))) {
-                            $continue = true;
-                        }
+                        $db_host = $this->askInteractiveQuestion("<info>Database Host</info>: ", '127.0.0.1', 6, false, false, "Please enter a host address");
+                        $db_port = $this->askInteractiveQuestion("<info>Database Port</info>: ", '3306', 6, false, false, "Please enter a host port number");
+                        $db_name = $this->askInteractiveQuestion("<info>Database Name</info>: ", null, 6, false, false, "Please enter name of the database you wish to connect with");
+                        $db_user = $this->askInteractiveQuestion("<info>Database User Name</info>: ", null, 6, false, false, "Please enter your user name to connect with the database");
+                        $db_password = $this->askInteractiveQuestion("<info>Database User Password</info>: ", null, 6, false, true, "Please enter your user password to connect with the database");
 
                         $output->write([self::MCA, self::CLL, self::MCA, self::CLL, self::MCA, self::CLL]);
-                    } else if (false == $isDatabaseAccessible) {
-                        $interactiveQuestion = new Question("\n      <comment>Database <comment>$db_name</comment> does not exist. Proceed with creating database? [Y/N]</comment> ", 'Y');
 
-                        if ('Y' === strtoupper($this->questionHelper->ask($input, $output, $interactiveQuestion))) {
-                            $output->write([self::MCA, self::CLL, self::MCA, self::CLL]);
-                            
-                            // Create Database
-                            if (false == $this->createDatabase($db_host, $db_port, $db_name, $db_user, $db_password)) {
-                                $output->writeln([
-                                    "<fg=red;>  [x]</> An unexpected error occurred while trying to create database <comment>$db_name</comment>.</>",
-                                    "\n  Exiting evaluation process.\n"
-                                ]);
-                            }
-                        } else {
-                            $output->write([self::MCA, self::CLL, self::MCA, self::CLL]);
+                        list($isServerAccessible, $isDatabaseAccessible) = $this->refreshDatabaseConnection($db_host, $db_port, $db_name, $db_user, $db_password);
 
+                        if (false == $isServerAccessible) {
                             $interactiveQuestion = new Question("\n      <comment>Unable to connect with your database server, please check the details provided.\n      Do you wish to try again? [Y/N]</comment> ", 'Y');
 
                             if ('Y' === strtoupper($this->questionHelper->ask($input, $output, $interactiveQuestion))) {
@@ -154,41 +141,67 @@ class ConfigureHelpdesk extends Command
                             }
 
                             $output->write([self::MCA, self::CLL, self::MCA, self::CLL, self::MCA, self::CLL]);
+                        } else if (false == $isDatabaseAccessible) {
+                            $interactiveQuestion = new Question("\n      <comment>Database <comment>$db_name</comment> does not exist. Proceed with creating database? [Y/N]</comment> ", 'Y');
+
+                            if ('Y' === strtoupper($this->questionHelper->ask($input, $output, $interactiveQuestion))) {
+                                $output->write([self::MCA, self::CLL, self::MCA, self::CLL]);
+
+                                // Create Database
+                                if (false == $this->createDatabase($db_host, $db_port, $db_name, $db_user, $db_password)) {
+                                    $output->writeln([
+                                        "<fg=red;>  [x]</> An unexpected error occurred while trying to create database <comment>$db_name</comment>.</>",
+                                        "\n  Exiting evaluation process.\n"
+                                    ]);
+                                }
+                            } else {
+                                $output->write([self::MCA, self::CLL, self::MCA, self::CLL]);
+
+                                $interactiveQuestion = new Question("\n      <comment>Unable to connect with your database server, please check the details provided.\n      Do you wish to try again? [Y/N]</comment> ", 'Y');
+
+                                if ('Y' === strtoupper($this->questionHelper->ask($input, $output, $interactiveQuestion))) {
+                                    $continue = true;
+                                }
+
+                                $output->write([self::MCA, self::CLL, self::MCA, self::CLL, self::MCA, self::CLL]);
+                            }
                         }
-                    }
-                } while (true == $continue);
+                    } while (true == $continue);
 
-                list($isServerAccessible, $isDatabaseAccessible) = $this->refreshDatabaseConnection($db_host, $db_port, $db_name, $db_user, $db_password);
+                    list($isServerAccessible, $isDatabaseAccessible) = $this->refreshDatabaseConnection($db_host, $db_port, $db_name, $db_user, $db_password);
 
-                if (true == $isServerAccessible && true == $isDatabaseAccessible) {
-                    $databaseUrl = sprintf("mysql://%s:%s@%s:%s/%s", $db_user, $db_password, $db_host, $db_port, $db_name);
+                    if (true == $isServerAccessible && true == $isDatabaseAccessible) {
+                        $databaseUrl = sprintf("mysql://%s:%s@%s:%s/%s", $db_user, $db_password, $db_host, $db_port, $db_name);
 
-                    $output->writeln("\n  [-] Switching to database <info>$db_name</info>");
+                        $output->writeln("\n  [-] Switching to database <info>$db_name</info>");
 
-                    try {
-                        $process = new Process(["php", "bin/console", "uvdesk_wizard:env:update", "DATABASE_URL", $databaseUrl]);
-                        $process->setWorkingDirectory($this->projectDirectory);
-                        $process->mustRun();
+                        try {
+                            $process = new Process(["php", "bin/console", "uvdesk_wizard:env:update", "DATABASE_URL", $databaseUrl]);
+                            $process->setWorkingDirectory($this->projectDirectory);
+                            $process->mustRun();
 
-                        $output->writeln("  <info>[v]</info> Successfully switched to database <info>$db_name</info>\n");
-                    } catch (\Exception $e) {
-                        $output->writeln([
-                            "<fg=red;>  [x]</> Failed to update .env with updated database credentials.</>",
-                            "\n  Exiting evaluation process.\n"
-                        ]);
+                            $output->writeln("  <info>[v]</info> Successfully switched to database <info>$db_name</info>\n");
+                        } catch (\Exception $e) {
+                            $output->writeln([
+                                "<fg=red;>  [x]</> Failed to update .env with updated database credentials.</>",
+                                "\n  Exiting evaluation process.\n"
+                            ]);
+
+                            return 1;
+                        }
+                    } else {
+                        $output->writeln("\n  Exiting evaluation process.\n");
 
                         return 1;
                     }
                 } else {
+                    $output->write(["\033[1A", "\033[K", "\033[1A", "\033[K"]);
                     $output->writeln("\n  Exiting evaluation process.\n");
 
                     return 1;
                 }
             } else {
-                $output->write(["\033[1A", "\033[K", "\033[1A", "\033[K"]);
-                $output->writeln("\n  Exiting evaluation process.\n");
-
-                return 1;
+                throw new \RuntimeException("Unable to establish a connection with the database server. Please provide a working database connection or use the interactive mode");
             }
         } else {
             $output->writeln("  <info>[v]</info> Successfully established a connection with database <info>$db_name</info>\n");
@@ -220,43 +233,47 @@ class ConfigureHelpdesk extends Command
 
             if ($currentMigrationVersion != $latestMigrationVersion) {
                 $output->writeln("  <comment>[!]</comment> The current database schema is not up-to-date with the current mapping metadata.");
-                $interactiveQuestion = new Question("\n      <comment>Update your database schema to the current mapping metadata? [Y/N]</comment> ", 'Y');
-    
-                if ('Y' === strtoupper($this->questionHelper->ask($input, $output, $interactiveQuestion))) {
-                    $output->writeln([
-                        "",
-                        "      Please wait while your database is being migrated from version <comment>$currentMigrationVersion</comment> to <info>$latestMigrationVersion</info>.",
-                        "      This could take up to a few minutes.\n",
-                    ]);
 
-                    try {
-                        // Migrate database to latest schematic version
-                        $process = new Process(["php", "bin/console", "doctrine:migrations:migrate", "--no-interaction", "--quiet"]);
-                        $process->setTimeout(900);
-                        $process->setWorkingDirectory($this->projectDirectory);
-                        $process->mustRun();
-    
-                        // Load database fixtures to populate initial dataset
-                        $process = new Process(["php", "bin/console", "doctrine:fixtures:load", "--append"]);
-                        $process->setTimeout(120);
-                        $process->setWorkingDirectory($this->projectDirectory);
-                        $process->mustRun();
+                if (!$noInteraction) {
 
-                        $output->writeln("  <info>[v]</info> Database successfully migrated to the latest migration version <comment>$latestMigrationVersion</comment> to <info>$latestMigrationVersion</info>.\n");
-                    } catch (\Exception $e) {
+                    $interactiveQuestion = new Question("\n      <comment>Update your database schema to the current mapping metadata? [Y/N]</comment> ", 'Y');
+
+                    if ('Y' !== strtoupper($this->questionHelper->ask($input, $output, $interactiveQuestion))) {
                         $output->writeln([
-                            "\n  <fg=red;>[x]</> Unable to successfully migrate to latest database schematic version.",
+                            "\n  <comment>[!]</comment> Skipping database schema migration.",
                             "\n  Exiting evaluation process.\n"
                         ]);
-        
+
                         return 1;
                     }
-                } else {
+                }
+
+                $output->writeln([
+                    "",
+                    "      Please wait while your database is being migrated from version <comment>$currentMigrationVersion</comment> to <info>$latestMigrationVersion</info>.",
+                    "      This could take up to a few minutes.\n",
+                ]);
+
+                try {
+                    // Migrate database to latest schematic version
+                    $process = new Process(["php", "bin/console", "doctrine:migrations:migrate", "--no-interaction", "--quiet"]);
+                    $process->setTimeout(900);
+                    $process->setWorkingDirectory($this->projectDirectory);
+                    $process->mustRun();
+
+                    // Load database fixtures to populate initial dataset
+                    $process = new Process(["php", "bin/console", "doctrine:fixtures:load", "--append"]);
+                    $process->setTimeout(120);
+                    $process->setWorkingDirectory($this->projectDirectory);
+                    $process->run();
+
+                    $output->writeln("  <info>[v]</info> Database successfully migrated from version <comment>$currentMigrationVersion</comment> to <info>$latestMigrationVersion</info>.\n");
+                } catch (\Exception $e) {
                     $output->writeln([
-                        "\n  <fg=red;>[x]</> There are entities that have not been updated to the <info>$databaseName</info> database yet.",
+                        "\n  <fg=red;>[x]</> Unable to successfully migrate to latest database schematic version.",
                         "\n  Exiting evaluation process.\n"
                     ]);
-    
+
                     return 1;
                 }
             } else {
@@ -292,68 +309,83 @@ class ConfigureHelpdesk extends Command
 
         if (empty($userInstance)) {
             $output->writeln("  <comment>[!]</comment> No active user account found with super admin privileges.");
-            $interactiveQuestion = new Question("\n      <comment>Create a new user account with super admin privileges? [Y/N]</comment> ", 'Y');
 
-            if ('Y' === strtoupper($this->questionHelper->ask($input, $output, $interactiveQuestion))) {
-                $output->write(["\033[1A", "\033[K", "\033[1A", "\033[K"]);
-                $output->writeln("\n      <comment>Please enter the following details:</comment>\n");
-    
-                $warningFlag = false;
+            if (!$noInteraction) {
+                $interactiveQuestion = new Question("\n      <comment>Create a new user account with super admin privileges? [Y/N]</comment> ", 'Y');
 
-                do {
-                    $u_email = $this->askInteractiveQuestion("<info>Email</info>: ", null, 6, false, false, "Please enter a valid email address");
-                    $u_email = filter_var($u_email, FILTER_SANITIZE_EMAIL);
-                    $this->userEmail = $u_email;
+                if ('Y' === strtoupper($this->questionHelper->ask($input, $output, $interactiveQuestion))) {
+                    $output->write(["\033[1A", "\033[K", "\033[1A", "\033[K"]);
+                    $output->writeln("\n      <comment>Please enter the following details:</comment>\n");
 
-                    if ($warningFlag) {
-                        $output->write([self::MCA, self::CLL]);
-                    }
-    
-                    if (false == filter_var($u_email, FILTER_VALIDATE_EMAIL)) {
-                        $output->writeln("      <comment>Warning</comment>: <comment>$u_email</comment> is not a valid email address");
-                        $warningFlag = true;
-                    }
-                } while (false == filter_var($u_email, FILTER_VALIDATE_EMAIL));
+                    $warningFlag = false;
 
-                $u_name = $this->askInteractiveQuestion("<info>Name</info>: ", null, 6, false, false, "Please enter your name");
+                    do {
+                        $u_email = $this->askInteractiveQuestion("<info>Email</info>: ", null, 6, false, false, "Please enter a valid email address");
+                        $u_email = filter_var($u_email, FILTER_SANITIZE_EMAIL);
+                        $this->userEmail = $u_email;
 
-                $warningFlag = false;
-                $this->userName = $u_name;
+                        if ($warningFlag) {
+                            $output->write([self::MCA, self::CLL]);
+                        }
 
-                do {
-                    $u_password = $this->askInteractiveQuestion("<info>Password</info>: ", null, 6, false, true, "Please enter your password");
-                    $u_cpassword = $this->askInteractiveQuestion("<info>Confirm Password</info>: ", null, 6, false, true, "Please enter your password");
+                        if (false == filter_var($u_email, FILTER_VALIDATE_EMAIL)) {
+                            $output->writeln("      <comment>Warning</comment>: <comment>$u_email</comment> is not a valid email address");
+                            $warningFlag = true;
+                        }
+                    } while (false == filter_var($u_email, FILTER_VALIDATE_EMAIL));
 
-                    if ($warningFlag) {
-                        $output->write([self::MCA, self::CLL]);
-                    }
-    
-                    if ($u_password != $u_cpassword) {
-                        $output->writeln("      <comment>Warning</comment>: Passwords do not match");
-                        $warningFlag = true;
-                    }
-                } while ($u_password != $u_cpassword);
+                    $u_name = $this->askInteractiveQuestion("<info>Name</info>: ", null, 6, false, false, "Please enter your name");
 
-                $output->write([self::MCA, self::CLL, self::MCA, self::CLL, self::MCA, self::CLL]);
+                    $warningFlag = false;
+                    $this->userName = $u_name;
 
-                try {
-                    $process = new Process(["php", "bin/console", "uvdesk_wizard:defaults:create-user", "ROLE_SUPER_ADMIN",  trim($u_name), $u_email, $u_password, '--no-interaction']);
-        
-                    $process->setWorkingDirectory($this->projectDirectory);
-                    $process->mustRun();
+                    do {
+                        $u_password = $this->askInteractiveQuestion("<info>Password</info>: ", null, 6, false, true, "Please enter your password");
+                        $u_cpassword = $this->askInteractiveQuestion("<info>Confirm Password</info>: ", null, 6, false, true, "Please enter your password");
 
-                    $output->writeln("  <info>[v]</info> User account created successfully.\n");
-                } catch (ProcessFailedException $e) {
-                    // Do nothing ...
-                    $output->writeln([
-                        "  <fg=red;>[x]</> An unexpected error occurred while creating the user account.\n",
-                        "\n  Exiting evaluation process.\n"
-                    ]);
+                        if ($warningFlag) {
+                            $output->write([self::MCA, self::CLL]);
+                        }
 
+                        if ($u_password != $u_cpassword) {
+                            $output->writeln("      <comment>Warning</comment>: Passwords do not match");
+                            $warningFlag = true;
+                        }
+                    } while ($u_password != $u_cpassword);
+
+                    $output->write([self::MCA, self::CLL, self::MCA, self::CLL, self::MCA, self::CLL]);
+
+                } else {
+                    $output->writeln("\n  <comment>[!]</comment> Skipping creation of a super admin account.");
                     return 1;
                 }
             } else {
-                $output->writeln("\n  <comment>[!]</comment> Skipping creation of a super admin account.");
+                // Default admin credentials
+                $u_email = getenv('SUPERUSER_EMAIL') ?? $_ENV['SUPERUSER_EMAIL'] ?? ($_SERVER['SUPERUSER_EMAIL'] ?? $env['SUPERUSER_EMAIL'] ?? "admin@example.com");
+                $u_name = getenv('SUPERUSER_NAME') ?? $_ENV['SUPERUSER_NAME'] ?? ($_SERVER['SUPERUSER_NAME'] ?? $env['SUPERUSER_NAME'] ?? "UVdesk Admin");
+                $u_password = getenv('SUPERUSER_PASSWORD') ?? $_ENV['SUPERUSER_PASSWORD'] ?? ($_SERVER['SUPERUSER_PASSWORD'] ?? $env['SUPERUSER_PASSWORD'] ?? "password");
+
+                $this->userEmail = $u_email;
+                $this->userName = $u_name;
+            }
+
+            $output->writeln("\n      <comment>Creating a new user account with super admin privileges...</comment>\n");
+
+            try {
+                $process = new Process(["php", "bin/console", "uvdesk_wizard:defaults:create-user", "ROLE_SUPER_ADMIN",  trim($u_name), $u_email, $u_password, '--no-interaction']);
+
+                $process->setWorkingDirectory($this->projectDirectory);
+                $process->mustRun();
+
+                $output->writeln("  <info>[v]</info> User account created successfully.\n");
+            } catch (ProcessFailedException $e) {
+                // Do nothing ...
+                $output->writeln([
+                    "  <fg=red;>[x]</> An unexpected error occurred while creating the user account.\n",
+                    "\n  Exiting evaluation process.\n"
+                ]);
+
+                return 1;
             }
         } else {
             $output->writeln("  <info>[v]</info> An account with support role <comment>SUPER_ADMIN</comment> exists.\n");
@@ -531,7 +563,8 @@ class ConfigureHelpdesk extends Command
         $env = (new Dotenv())
             ->parse(file_get_contents($this->container->getParameter('kernel.project_dir') . '/.env'));
         
-        $it = explode('@', substr($env['DATABASE_URL'], strpos($env['DATABASE_URL'], "://") + 3));
+        $dbUrl = getenv('DATABASE_URL') ?? $_ENV['DATABASE_URL'] ?? ($_SERVER['DATABASE_URL'] ?? $env['DATABASE_URL']); // get from propper ENV before trying for .env
+        $it = explode('@', substr($dbUrl, strpos($dbUrl, "://") + 3));
         
         $name = substr($it[1], strpos($it[1], "/") + 1);
         list($user, $password) = explode(':', $it[0]);


### PR DESCRIPTION
### 1. Why is this change necessary?

Added the possibility to run the wizard in 'no-interaction' mode. This should help to run the wizard directly from code, for example when using uvdesk dockerized. _Just add `php bin/console uvdesk:configure-helpdesk -n` to the entrypoint.sh script_


### 2. What does this change do, exactly?

- Adds a "--no-interaction" switch to the "uvdesk:configure-helpdesk" command
- Makes all three steps (in Console/Wizard/ConfigureHelpdesk.php) to check if "no-interaction mode" is active. If yes, skip the questions and just do it.
- Modified `getUpdatedDatabaseCredentials` to first check for real ENVs before taking it from a .env

**changes to bundles.php**
I've added `Doctrine\Bundle\FixturesBundle\DoctrineFixturesBundle::class => ['all' => true],` to the `bundles.php`. This seems to fix an error when running the command `php bin/console doctrine:fixtures:load --append`

### 3. Please link to the relevant issues (if any).

none
